### PR TITLE
Sound jitter, distortion, and delay

### DIFF
--- a/rplugin/python3/orchestra/util.py
+++ b/rplugin/python3/orchestra/util.py
@@ -40,9 +40,7 @@ class VimMix():
 
 
 def play_sound(file):
-    '''
-    chunk = length of data to read.
-    '''
+
     if not os.path.isfile(file):
         return False
 

--- a/rplugin/python3/orchestra/util.py
+++ b/rplugin/python3/orchestra/util.py
@@ -39,12 +39,13 @@ class VimMix():
         self.vim.command('echom "{0}"'.format(thing))
 
 
-def play_sound(file, chunk=1024):
+def play_sound(file):
     '''
     chunk = length of data to read.
     '''
     if not os.path.isfile(file):
         return False
+
     # open the file for reading.
     wf = wave.open(file, 'rb')
     # create an audio object
@@ -56,13 +57,11 @@ def play_sound(file, chunk=1024):
                     rate = wf.getframerate(),
                     output = True)
 
-    # read data (based on the chunk size)
-    data = wf.readframes(chunk)
-    # play stream (looping from beginning of file to the end)
-    while data != '':
-        # writing to the stream is what *actually* plays the sound.
-        stream.write(data)
-        data = wf.readframes(chunk)
+    # read data
+    data = wf.readframes(wf.getnframes())
+    # play sound
+    stream.write(data)
+
     # cleanup stuff.
     stream.close()    
     p.terminate()


### PR DESCRIPTION
This fixes the above for me.

This should work fine because
- it's called in its own thread so it won't block.
- the sound files should be small and won't bloat memory

It could also be further improved upon by creating a map of file paths to audio data to save time on re reading and opening an audio file.

In addition, if the symphony theme uses a consistent format for all it's audio files then only one stream needs to be created. That comes with the adding of locks with little gain, though.
